### PR TITLE
Wait for services to be available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test-shared-memory-service-manually:
 .PHONY: test-shared-memory-service-manually
 
 clean-maven:
-	$(MVN_COMMAND) clean -f modules/os-jdg-caching-service-configuration/pom.xml || true
+	$(MVN_COMMAND) clean -f modules/os-datagrid-online-services-configuration/pom.xml || true
 	$(MVN_COMMAND) clean -f functional-tests/pom.xml || true
 .PHONY: clean-maven
 

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -8,6 +8,9 @@
    <version>1.0.0-SNAPSHOT</version>
 
    <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+
       <infinispan-client-hotrod.version>8.4.0.Final-redhat-2</infinispan-client-hotrod.version>
       <openshift-client.version>2.6.1</openshift-client.version>
       <arquillian-junit-standalone.version>1.1.13.Final</arquillian-junit-standalone.version>

--- a/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
@@ -1,16 +1,20 @@
 package org.infinispan.online.service.caching;
 
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.infinispan.online.service.endpoint.HotRodTester;
 import org.infinispan.online.service.endpoint.RESTTester;
+import org.infinispan.online.service.utils.ReadinessCheck;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
@@ -24,9 +28,17 @@ public class CachingServiceTest {
    @ArquillianResource
    URL restService;
 
+   @ArquillianResource
+   OpenShiftClient openShiftClient;
 
+   ReadinessCheck readinessCheck = new ReadinessCheck();
    HotRodTester hotRodTester = new HotRodTester();
    RESTTester restTester = new RESTTester();
+
+   @Before
+   public void before() {
+      readinessCheck.waitUntilAllPodsAreReady(openShiftClient, 30, TimeUnit.SECONDS);
+   }
 
    @Test
    public void should_default_cache_be_accessible_via_hot_rod() throws IOException {

--- a/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
@@ -1,16 +1,20 @@
 package org.infinispan.online.service.sharedmemory;
 
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.infinispan.online.service.endpoint.HotRodTester;
 import org.infinispan.online.service.endpoint.RESTTester;
+import org.infinispan.online.service.utils.ReadinessCheck;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
@@ -24,8 +28,17 @@ public class SharedMemoryServiceTest {
    @ArquillianResource
    URL restService;
 
+   @ArquillianResource
+   OpenShiftClient openShiftClient;
+
+   ReadinessCheck readinessCheck = new ReadinessCheck();
    HotRodTester hotRodTester = new HotRodTester();
    RESTTester restTester = new RESTTester();
+
+   @Before
+   public void before() {
+      readinessCheck.waitUntilAllPodsAreReady(openShiftClient, 30, TimeUnit.SECONDS);
+   }
 
    @Test
    public void should_default_cache_be_accessible_via_hot_rod() throws IOException {

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
@@ -1,0 +1,34 @@
+package org.infinispan.online.service.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+
+public class ReadinessCheck {
+
+   public void waitUntilAllPodsAreReady(OpenShiftClient client, long timeout, TimeUnit unit) {
+      long endTime = TimeUnit.MILLISECONDS.convert(timeout, unit) + System.currentTimeMillis();
+      long backoffCounter = 0;
+      while (System.currentTimeMillis() - endTime < 0) {
+         Set<Pod> notReadyPods = getNotReadyPods(client);
+         if (notReadyPods.isEmpty()) {
+            break;
+         }
+         System.out.println("Some pods are not ready: " + notReadyPods);
+         LockSupport.parkNanos(++backoffCounter * 10_000);
+      }
+   }
+
+   private Set<Pod> getNotReadyPods(OpenShiftClient client) {
+      return client.pods().list().getItems().stream()
+         .filter(pod -> pod.getStatus().getConditions().stream()
+            .filter(condition -> "Ready".equals(condition.getType()))
+            .filter(condition -> "False".equals(condition.getStatus()))
+            .findAny().isPresent())
+         .collect(Collectors.toSet());
+   }
+}


### PR DESCRIPTION
It turned out that we need to wait until all Pods are available before starting the tests. 

I proposed adding this functionality directly to Arquillian CUBE: https://github.com/arquillian/arquillian-cube/issues/832