### PR TITLE
Update image to utilise services.xml configuration

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 name: "jboss-dataservices/datagrid-online-services"
 description: "Red Hat JBoss Data Grid Services"
 version: "1.0"
-from: "jboss-datagrid-7/datagrid72-openshift:1.0"
+from: "jboss-datagrid-7/datagrid72-openshift:dev"
 labels:
     - name: "io.k8s.description"
       value: "Provides a scalable in-memory caching solution for fast access to large volumes of data."

--- a/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/caching-service.cli
+++ b/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/caching-service.cli
@@ -1,13 +1,16 @@
-embed-server --server-config=cloud.xml --std-out=echo
-
-if (result != 1) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=default:read-attribute(name=owners)
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=default:write-attribute(name=owners, value=1)
-end-if
+embed-server --server-config=services.xml --std-out=echo
 
 if (outcome == success) of /subsystem=datagrid-infinispan-endpoint/rest-connector=rest-connector/authentication=AUTHENTICATION:read-resource
    /subsystem=datagrid-infinispan-endpoint/rest-connector=rest-connector/authentication=AUTHENTICATION:remove
 end-if
 
-/subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=default/memory=OFF-HEAP:add(size=$eviction_total_memory_bytes, eviction=MEMORY)
+if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=shared-memory-service:read-resource
+   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=shared-memory-service:remove
+end-if
+
+/subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=caching-service/memory=OFF-HEAP:add(size=$eviction_total_memory_bytes, eviction=MEMORY)
+
+/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=default:write-attribute(name=configuration, value=caching-service)
+/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:write-attribute(name=configuration, value=caching-service)
 
 stop-embedded-server

--- a/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
+++ b/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
@@ -1,40 +1,10 @@
-embed-server --server-config=cloud.xml --std-out=echo
+embed-server --server-config=services.xml --std-out=echo
 
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/replicated-cache=repl:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/replicated-cache=repl:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/replicated-cache-configuration=replicated:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/replicated-cache-configuration=replicated:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=async:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=async:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=indexed:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=indexed:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=memory-bounded:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=memory-bounded:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-file-store-passivation:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-file-store-passivation:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-file-store:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-file-store:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-jdbc-binary-keyed:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-jdbc-binary-keyed:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-jdbc-string-keyed:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-jdbc-string-keyed:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-leveldb-store:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=persistent-leveldb-store:remove
-end-if
-if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=transactional:read-resource
-   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=transactional:remove
+if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=caching-service:read-resource
+   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=caching-service:remove
 end-if
 
-/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=default:write-attribute(name=configuration, value=persistent-file-store-write-behind)
-/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:write-attribute(name=configuration, value=persistent-file-store-write-behind)
+/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=default:write-attribute(name=configuration, value=shared-memory-service)
+/subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:write-attribute(name=configuration, value=shared-memory-service)
 
 stop-embedded-server

--- a/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
+++ b/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
@@ -4,6 +4,10 @@ if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=cluste
    /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=caching-service:remove
 end-if
 
+if (result != $num_owners) of /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=shared-memory-service:read-attribute(name=owners)
+   /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=shared-memory-service:write-attribute(name=owners, value=$num_owners)
+end-if
+
 /subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=default:write-attribute(name=configuration, value=shared-memory-service)
 /subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:write-attribute(name=configuration, value=shared-memory-service)
 

--- a/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/SharedMemoryServiceConfigurationTest.java
+++ b/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/SharedMemoryServiceConfigurationTest.java
@@ -19,13 +19,13 @@ public class SharedMemoryServiceConfigurationTest {
    ConfigurationScriptInvoker configurationScriptInvoker = new ConfigurationScriptInvoker();
    TestResourceLocator testResourceLocator = new TestResourceLocator();
 
-   Path cloudXml = testServerLocator.locateServer().resolve("standalone/configuration/cloud.xml");
+   Path servicesXml = testServerLocator.locateServer().resolve("standalone/configuration/services.xml");
    Path jbossHome = testServerLocator.locateServer();
 
    @Before
    public void beforeTest() throws IOException {
-      Path baselineConfiguration = testResourceLocator.locateFile("caching-service/cloud-7.2.xml");
-      Files.copy(baselineConfiguration, cloudXml, StandardCopyOption.REPLACE_EXISTING);
+      Path baselineConfiguration = testResourceLocator.locateFile("caching-service/services-7.2.xml");
+      Files.copy(baselineConfiguration, servicesXml, StandardCopyOption.REPLACE_EXISTING);
    }
 
    @Test
@@ -35,9 +35,9 @@ public class SharedMemoryServiceConfigurationTest {
 
       //then
       ResultAssertion.assertThat(result).printResult().isOk();
-      XmlAssertion.assertThat(cloudXml).hasXPath("//*[local-name()='memcached-connector']");
-      XmlAssertion.assertThat(cloudXml).hasXPath("//*[local-name()='rest-connector']");
-      XmlAssertion.assertThat(cloudXml).hasXPath("//*[local-name()='hotrod-connector']");
+      XmlAssertion.assertThat(servicesXml).hasXPath("//*[local-name()='memcached-connector']");
+      XmlAssertion.assertThat(servicesXml).hasXPath("//*[local-name()='rest-connector']");
+      XmlAssertion.assertThat(servicesXml).hasXPath("//*[local-name()='hotrod-connector']");
    }
 
    @Test
@@ -48,7 +48,7 @@ public class SharedMemoryServiceConfigurationTest {
       //then
       ResultAssertion.assertThat(result).printResult().isOk();
 
-      XmlAssertion.assertThat(cloudXml)
+      XmlAssertion.assertThat(servicesXml)
       .hasXPath("//*[local-name()='stack' and @name='kubernetes']")
       .hasXPath("//*[local-name()='transport' and @type='TCP']")
       .hasXPath("//*[local-name()='protocol' and @type='kubernetes.KUBE_PING']")
@@ -71,21 +71,13 @@ public class SharedMemoryServiceConfigurationTest {
       //then
       ResultAssertion.assertThat(result).printResult().isOk();
 
-      XmlAssertion.assertThat(cloudXml)
-         .hasXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-file-store-write-behind']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='async']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='indexed']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='memory-bounded']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-file-store-passivation']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-file-store']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-jdbc-binary-keyed']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-jdbc-string-keyed']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='persistent-leveldb-store']")
-         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='transactional']")
+      XmlAssertion.assertThat(servicesXml)
+         .hasXPath("//*[local-name()='distributed-cache-configuration' and @name='shared-memory-service']")
+         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='caching-service']")
+         .hasXPath("//*[local-name()='distributed-cache' and @name='default' and @configuration='shared-memory-service']")
+         .hasXPath("//*[local-name()='distributed-cache' and @name='memcachedCache' and @configuration='shared-memory-service']");
 //  https://issues.jboss.org/browse/ISPN-8341
 //         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='default']")
 //         .hasNoXPath("//*[local-name()='distributed-cache-configuration' and @name='memcachedCache']")
-         .hasXPath("//*[local-name()='distributed-cache' and @name='default' and @configuration='persistent-file-store-write-behind']")
-         .hasXPath("//*[local-name()='distributed-cache' and @name='memcachedCache' and @configuration='persistent-file-store-write-behind']");
    }
 }

--- a/modules/os-datagrid-online-services-configuration/src/test/resources/caching-service/services-7.2.xml
+++ b/modules/os-datagrid-online-services-configuration/src/test/resources/caching-service/services-7.2.xml
@@ -160,59 +160,13 @@
             <cache-container name="clustered" default-cache="default" statistics="true">
                 <transport lock-timeout="60000"/>
                 <global-state/>
-                <distributed-cache-configuration name="transactional">
-                    <transaction mode="NON_XA" locking="PESSIMISTIC"/>
+                <distributed-cache-configuration name="shared-memory-service" owners="2">
+                    <partition-handling when-split="ALLOW_READ_WRITES" merge-policy="REMOVE_ALL"/>
                 </distributed-cache-configuration>
-                <distributed-cache-configuration name="async" mode="ASYNC"/>
-                <replicated-cache-configuration name="replicated"/>
-                <distributed-cache-configuration name="persistent-file-store">
-                    <file-store shared="false" fetch-state="true" passivation="false"/>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="indexed">
-                    <indexing index="LOCAL" auto-config="true"/>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="memory-bounded">
-                    <memory>
-                        <object size="10000"/>
-                    </memory>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="persistent-file-store-passivation">
-                    <memory>
-                        <object size="10000"/>
-                    </memory>
-                    <file-store shared="false" fetch-state="true" passivation="true">
-                        <write-behind modification-queue-size="1024" thread-pool-size="1"/>
-                    </file-store>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="persistent-file-store-write-behind">
-                    <file-store shared="false" fetch-state="true" passivation="false">
-                        <write-behind modification-queue-size="1024" thread-pool-size="1"/>
-                    </file-store>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="persistent-leveldb-store">
-                    <leveldb-store shared="false" fetch-state="true" passivation="false"/>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="persistent-jdbc-string-keyed">
-                    <string-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="false" purge="false" shared="false" passivation="false">
-                        <string-keyed-table prefix="ISPN">
-                            <id-column name="id" type="VARCHAR"/>
-                            <data-column name="datum" type="BINARY"/>
-                            <timestamp-column name="version" type="BIGINT"/>
-                        </string-keyed-table>
-                        <write-behind modification-queue-size="1024" thread-pool-size="1"/>
-                    </string-keyed-jdbc-store>
-                </distributed-cache-configuration>
-                <distributed-cache-configuration name="persistent-jdbc-binary-keyed">
-                    <binary-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="true" purge="false" shared="false" passivation="false">
-                        <binary-keyed-table prefix="ISPN">
-                            <id-column name="id" type="VARCHAR"/>
-                            <data-column name="datum" type="BINARY"/>
-                            <timestamp-column name="version" type="BIGINT"/>
-                        </binary-keyed-table>
-                    </binary-keyed-jdbc-store>
+                <distributed-cache-configuration name="caching-service" owners="1">
+                    <partition-handling when-split="ALLOW_READ_WRITES" merge-policy="REMOVE_ALL"/>
                 </distributed-cache-configuration>
                 <distributed-cache name="default"/>
-                <replicated-cache name="repl" configuration="replicated"/>
                 <distributed-cache name="memcachedCache"/>
             </cache-container>
         </subsystem>

--- a/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
+++ b/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
@@ -2,7 +2,7 @@
 
 PROFILE=${PROFILE:=CACHING-SERVICE}
 PROFILE=${PROFILE,,}
-CONFIG_FILE=${CONFIG_FILE:=cloud.xml}
+CONFIG_FILE=${CONFIG_FILE:=services.xml}
 JGROUPS_STACK=kubernetes
 LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
 

--- a/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
+++ b/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
@@ -14,7 +14,7 @@ CONFIGURE_SCRIPTS=(
 
 source $JBOSS_HOME/bin/launch/configure.sh
 
-$JBOSS_HOME/bin/launch/jdg-online-configuration.sh --profile $PROFILE "eviction_total_memory_bytes=$EVICTION_TOTAL_MEMORY_B"
+$JBOSS_HOME/bin/launch/jdg-online-configuration.sh --profile $PROFILE "eviction_total_memory_bytes=$EVICTION_TOTAL_MEMORY_B" "num_owners=${NUMBER_OF_OWNERS}"
 if [[ $? -ne 0 ]]; then
     echo "WARNING: Profile ${PROFILE} doesn't exist. Falling back to Caching Service."
 fi

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -233,6 +233,10 @@
                            {
                               "name": "APP_PASS",
                               "value": "${APPLICATION_PASSWORD}"
+                           },
+                           {
+                               "name": "NUMBER_OF_OWNERS",
+                               "value": "${NUMBER_OF_OWNERS}"
                            }
                         ],
                         "image": "${IMAGE}",
@@ -354,6 +358,12 @@
          "name": "NUMBER_OF_INSTANCES",
          "required": true,
          "value": "1"
-      }
+      },
+      {
+        "description": "Number of replicas for each cache entry in the cluster.",
+        "name": "NUMBER_OF_OWNERS",
+        "required": false,
+        "value": "2"
+     }
    ]
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8406

Also allows users to specify the num of owners for the shared-memory-service. 

Don't integrate until the datagrid image has been re-spun with JDG DR3 and this has been tested. 