### PR TITLE
Run tests in EAP - WIP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                configFileProvider([configFile(fileId: 'maven-settings-with-prod', variable: 'MAVEN_SETTINGS')]) {
                   script {
                      try {
-                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" test-ci'
+                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS -Dorg.apache.maven.user-settings=$MAVEN_SETTINGS" test-ci'
                      } finally {
                         sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" clean-ci'
                      }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,27 +22,15 @@ pipeline {
          }
       }
 
-      stage('Unit tests') {
-         steps {
-            script {
-               configFileProvider([configFile(fileId: 'maven-settings-with-prod', variable: 'MAVEN_SETTINGS')]) {
-                  script {
-                     sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" test-unit'
-                  }
-               }
-            }
-         }
-      }
-
-      stage('Functional and OpenShift tests') {
+      stage('Unit and Functional tests') {
          steps {
             script {
                configFileProvider([configFile(fileId: 'maven-settings-with-prod', variable: 'MAVEN_SETTINGS')]) {
                   script {
                      try {
-                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" start-openshift-with-catalog build-image push-image-to-local-openshift test-functional'
+                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" test-ci'
                      } finally {
-                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" stop-openshift clean-docker'
+                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" clean-ci'
                      }
                   }
                }

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ push-image-to-local-openshift: _add_openshift_push_permissions _login_to_openshi
 .PHONY: push-image-to-local-openshift
 
 test-functional:
-	$(MVN_COMMAND) clean test -f functional-tests/pom.xml -Dimage=$(_IMAGE) -Dkubernetes.auth.token=$(shell oc whoami -t)
+	$(MVN_COMMAND) -Dimage=$(_IMAGE) -Dkubernetes.auth.token=$(shell oc whoami -t) clean test -f functional-tests/pom.xml
 .PHONY: test-functional
 
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ _login_to_openshift:
 
 _add_openshift_push_permissions:
 	oc adm policy add-role-to-user system:registry developer || true
-	oc adm policy add-role-to-user admin developer -n myproject || true
+	oc adm policy add-role-to-user admin developer -n ${_TEST_PROJECT} || true
 	oc adm policy add-role-to-user system:image-builder developer || true
 .PHONY: _add_openshift_push_permissions
 
@@ -91,7 +91,7 @@ push-image-to-local-openshift: _add_openshift_push_permissions _login_to_openshi
 .PHONY: push-image-to-local-openshift
 
 test-functional:
-	$(MVN_COMMAND) clean test -f functional-tests/pom.xml -Dimage=$(_IMAGE)
+	$(MVN_COMMAND) clean test -f functional-tests/pom.xml -Dimage=$(_IMAGE) -Dkubernetes.auth.token=$(shell oc whoami -t)
 .PHONY: test-functional
 
 test-unit:
@@ -154,7 +154,7 @@ clean: clean-docker clean-maven stop-openshift
 test-ci: clean test-unit start-openshift-with-catalog build-image push-image-to-local-openshift test-functional
 .PHONY: test-ci
 
-clean-ci: clean-docker clean-templates-in-helper-namespace stop-openshift #avoid cleaning Maven as we need results to be reported by the job
+clean-ci: clean-docker stop-openshift #avoid cleaning Maven as we need results to be reported by the job
 .PHONY: clean-ci
 
 apb-build:

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,11 @@ clean-docker:
 clean: clean-docker clean-maven stop-openshift
 .PHONY: clean
 
-test-ci: clean test-unit start-openshift-with-catalog build-image push-image-to-local-openshift test-functional clean
+test-ci: clean test-unit start-openshift-with-catalog build-image push-image-to-local-openshift test-functional
 .PHONY: test-ci
+
+clean-ci: clean-docker clean-templates-in-helper-namespace stop-openshift #avoid cleaning Maven as we need results to be reported by the job
+.PHONY: clean-ci
 
 apb-build:
 	(\

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -17,6 +17,7 @@
       <assertj-core.version>3.8.0</assertj-core.version>
       <rest-assured.version>3.0.5</rest-assured.version>
       <version.chameleon>1.0.0.Beta2</version.chameleon>
+      <org.apache.maven.user-settings></org.apache.maven.user-settings>
    </properties>
 
    <dependencyManagement>
@@ -114,6 +115,7 @@
                   <!--Custom DNS resolver for OpenShift routes-->
                   <sun.net.spi.nameservice.provider.1>dns,CEArquillianNameService</sun.net.spi.nameservice.provider.1>
                   <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
+                  <org.apache.maven.user-settings>${org.apache.maven.user-settings}</org.apache.maven.user-settings>
                </systemPropertyVariables>
             </configuration>
          </plugin>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -10,33 +10,44 @@
    <properties>
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
-
-      <infinispan-client-hotrod.version>8.5.0.DR2-redhat-1</infinispan-client-hotrod.version>
+      <version.arquillian.bom>1.1.8.Final</version.arquillian.bom>
+      <version.infinispan.bom>8.5.0.DR2-redhat-1</version.infinispan.bom>
       <openshift-client.version>3.0.3</openshift-client.version>
-      <arquillian-junit-standalone.version>1.1.13.Final</arquillian-junit-standalone.version>
       <arquillian-cube-openshift.version>1.9.0</arquillian-cube-openshift.version>
       <assertj-core.version>3.8.0</assertj-core.version>
       <rest-assured.version>3.0.5</rest-assured.version>
+      <version.chameleon>1.0.0.Beta2</version.chameleon>
    </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>org.jboss.arquillian</groupId>
+            <artifactId>arquillian-bom</artifactId>
+            <version>${version.arquillian.bom}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-bom</artifactId>
+            <version>${version.infinispan.bom}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
 
    <dependencies>
       <!-- https://github.com/arquillian/arquillian-cube/blob/master/docs/kubernetes.adoc#dealing-with-version-conflicts -->
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-client-hotrod</artifactId>
-         <version>${infinispan-client-hotrod.version}</version>
       </dependency>
-
       <dependency>
          <groupId>io.fabric8</groupId>
          <artifactId>openshift-client</artifactId>
          <version>${openshift-client.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.jboss.arquillian.junit</groupId>
-         <artifactId>arquillian-junit-standalone</artifactId>
-         <version>${arquillian-junit-standalone.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -63,5 +74,49 @@
          <version>${rest-assured.version}</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.jboss.arquillian.junit</groupId>
+         <artifactId>arquillian-junit-container</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.arquillian.container</groupId>
+         <artifactId>arquillian-container-chameleon</artifactId>
+         <version>${version.chameleon}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.resolver</groupId>
+         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+         <scope>compile</scope>
+      </dependency>
    </dependencies>
+
+   <build>
+      <resources>
+         <resource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+         </resource>
+      </resources>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.20</version>
+            <configuration>
+               <runOrder>alphabetical</runOrder>
+               <redirectTestOutputToFile>true</redirectTestOutputToFile>
+               <trimStackTrace>false</trimStackTrace>
+               <forkMode>once</forkMode>
+               <systemPropertyVariables>
+                  <https.protocols>TLSv1.2</https.protocols>
+                  <!--Custom DNS resolver for OpenShift routes-->
+                  <sun.net.spi.nameservice.provider.1>dns,CEArquillianNameService</sun.net.spi.nameservice.provider.1>
+                  <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
+               </systemPropertyVariables>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/functional-tests/src/test/java/org/infinispan/online/service/endpoint/RESTTester.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/endpoint/RESTTester.java
@@ -41,6 +41,7 @@ public class RESTTester implements EndpointTester {
       }
    }
 
+
    public void testIfEndpointIsProtected(URL urlToService) {
       post(urlToService.toString() + "rest/default/should_default_cache_be_accessible_via_REST", "test", 401, false);
    }

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/DeploymentHelper.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/DeploymentHelper.java
@@ -1,0 +1,17 @@
+package org.infinispan.online.service.utils;
+
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import java.io.File;
+
+public class DeploymentHelper {
+
+   public static File[] testLibs() {
+      return Maven.resolver().loadPomFromFile("pom.xml")
+         .resolve("org.infinispan:infinispan-client-hotrod",
+            "io.fabric8:openshift-client",
+            "org.assertj:assertj-core",
+            "io.rest-assured:rest-assured")
+         .withTransitivity().asFile();
+   }
+}

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftClientCreator.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftClientCreator.java
@@ -1,0 +1,20 @@
+package org.infinispan.online.service.utils;
+
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+public class OpenShiftClientCreator {
+
+   //TODO: Get namespace and username from env properties
+   private static final OpenShiftClient CLIENT = new DefaultOpenShiftClient(new ConfigBuilder()
+         .withNamespace("myproject")
+         .withUsername("developer")  //auth token is read from environment property KUBERNETES_AUTH_TOKEN
+         .build());
+
+   private OpenShiftClientCreator() {}
+
+   public static OpenShiftClient getClient() {
+      return CLIENT;
+   }
+}

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
@@ -1,0 +1,40 @@
+package org.infinispan.online.service.utils;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+public class OpenShiftHandle {
+
+   private static final String HTTP_PROTOCOL = "http";
+
+   private OpenShiftClient client;
+
+   public OpenShiftHandle(OpenShiftClient client) {
+      this.client = client;
+   }
+
+   public URL getServiceWithName(String resourceName) throws MalformedURLException {
+      ServiceSpec spec = client.services().withName(resourceName).get().getSpec();
+
+      if (spec != null) {
+         String host;
+         if (spec.getExternalName() != null && !spec.getExternalName().isEmpty()) {
+            host = spec.getExternalName();
+         } else {
+            host = spec.getClusterIP();
+         }
+         //use HTTP as the protocol is unimportant and we don't want to register custom handlers
+         return new URL(HTTP_PROTOCOL, host, spec.getPorts().get(0).getPort(), "/");
+      }
+      return null;
+   }
+
+   public List<Pod> getPodsWithLabel(String labelKey, String labelValue) throws MalformedURLException {
+      return client.pods().withLabel(labelKey, labelValue).list().getItems();
+   }
+}

--- a/functional-tests/src/test/resources/arquillian.xml
+++ b/functional-tests/src/test/resources/arquillian.xml
@@ -3,8 +3,15 @@
             xmlns="http://jboss.org/schema/arquillian"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <!-- Uncomment to have test archives exported to the file system for inspection -->
+    <!--
+    <engine>
+            <property name="deploymentExportPath">target/arquillian</property>
+    </engine>
+    -->
 
    <extension qualifier="openshift">
+      <property name="originServer">https://127.0.0.1:8443</property>
       <!--
          Just comment those two lines to run it efficiently while debugging. Just create those resources once
          and restart test only
@@ -12,8 +19,30 @@
       <property name="env.setup.script.url">setup.sh</property>
       <property name="env.teardown.script.url">destroy.sh</property>
       <property name="namespace.use.current">true</property>
+      <!-- For debugging purposes:
+         * comment out this line and start the definitions manually before the test via:
+            oc create -f target/classes/eap7-testrunner.json
+         * turn on port forwarding manually in a different console:
+            oc port-forward testrunner 9990 8787
+         * attach remote debugger to localhost:8787
+         * debug the test class
+         Note: The EAP pod has to have DEBUG=true in the json definition so that EAP start in debug mode
+      -->
+      <property name="definitionsFile">target/classes/eap7-testrunner.json</property>
       <property name="wait.for.service.list">caching-service-app-hotrod, shared-memory-service-app-hotrod, caching-service-app-http, shared-memory-service-app-http</property>
       <property name="env.script.env">image=${image}</property>
+      <property name="proxiedContainerPorts">testrunner:9990</property>
+      <!-- Fetch the logs from Openshift and pods, and save them into target/surefire-reports -->
+      <property name="logs.copy">true</property>
    </extension>
+
+   <container qualifier="testrunner" mode="suite" default="true">
+        <!-- Pod running remote tests. -->
+      <configuration>
+          <property name="chameleonTarget">jboss eap:7.0:remote</property>
+          <property name="username">admin</property>
+          <property name="password">Admin#70365</property>
+      </configuration>
+   </container>
 
 </arquillian>

--- a/functional-tests/src/test/resources/destroy.sh
+++ b/functional-tests/src/test/resources/destroy.sh
@@ -17,3 +17,9 @@ oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindin
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=shared-memory-service || true
 oc delete template caching-service || true
 oc delete template shared-memory-service || true
+
+oc delete service caching-service-app-http-helper-project
+oc delete service caching-service-app-hotrod-helper-project
+oc delete service shared-memory-service-app-http-helper-project
+oc delete service shared-memory-service-app-hotrod-helper-project
+

--- a/functional-tests/src/test/resources/eap7-testrunner.json
+++ b/functional-tests/src/test/resources/eap7-testrunner.json
@@ -1,0 +1,65 @@
+{
+   "apiVersion": "v1",
+   "kind": "Pod",
+   "metadata": {
+      "name": "testrunner",
+      "labels": {
+         "name": "testrunner"
+      }
+   },
+   "spec": {
+      "terminationGracePeriodSeconds": 0,
+      "containers": [
+         {
+            "name": "testrunner",
+            "readinessProbe": {
+               "exec": {
+                  "command": [
+                     "/bin/bash",
+                     "-c",
+                     "/opt/eap/bin/readinessProbe.sh"
+                  ]
+               }
+            },
+            "image": "jboss-eap-7/eap70-openshift:1.5-23",
+            "ports": [
+               {
+                  "containerPort": 8080,
+                  "protocol": "TCP"
+               },
+               {
+                  "containerPort": 9990,
+                  "protocol": "TCP"
+               },
+               {
+                  "containerPort": 9999,
+                  "protocol": "TCP"
+               },
+               {
+                  "containerPort": 8787,
+                  "protocol": "TCP"
+               }
+            ],
+            "env": [
+               {
+                  "name": "ADMIN_USERNAME",
+                  "value": "admin"
+               },
+               {
+                  "name": "ADMIN_PASSWORD",
+                  "value": "Admin#70365"
+               },
+               {
+                  "name": "KUBERNETES_AUTH_TOKEN",
+                  "value": "${kubernetes.auth.token}"
+               },
+               {
+                  "name" : "DEBUG",
+                  "value" : "false"
+               }
+            ]
+         }
+      ]
+   }
+}
+

--- a/functional-tests/src/test/resources/setup.sh
+++ b/functional-tests/src/test/resources/setup.sh
@@ -15,5 +15,6 @@ echo "Using image $IMAGE_NAME"
 
 oc create -f ../templates/caching-service.json
 oc create -f ../templates/shared-memory-service.json
+
 oc process caching-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -
 oc process shared-memory-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -


### PR DESCRIPTION
This is ready for review and merging.

* arquillian-cube is not able to inject resources such as URL or OpenShiftClient because it only works with arquillian-junit-standalone dependency, not with arquillian-junit-container dependency (this is not implemented in arq-cube), and we can't have both on classpath, that's also why the original tests have @RunAsClient - to simulate the original behaviour when the test runs outside OpenShift, not in-container
* I'd welcome suggestions how to better structure the 3 variants (InProject,CrossProject,Standalone (outside openshift)) as now I'm using subclassing