### PR TITLE
Increased Readiness/Liveness check timeouts

### DIFF
--- a/templates/caching-service.json
+++ b/templates/caching-service.json
@@ -239,7 +239,7 @@
                                  "/opt/datagrid/bin/livenessProbe.sh"
                               ]
                            },
-                           "initialDelaySeconds": 5,
+                           "initialDelaySeconds": 15,
                            "timeoutSeconds": 10,
                            "periodSeconds": 20,
                            "successThreshold": 1,
@@ -251,7 +251,7 @@
                                  "/opt/datagrid/bin/readinessProbe.sh"
                               ]
                            },
-                           "initialDelaySeconds": 7,
+                           "initialDelaySeconds": 17,
                            "timeoutSeconds": 10,
                            "periodSeconds": 20,
                            "successThreshold": 2,

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -247,7 +247,7 @@
                                  "/opt/datagrid/bin/livenessProbe.sh"
                               ]
                            },
-                           "initialDelaySeconds": 5,
+                           "initialDelaySeconds": 15,
                            "timeoutSeconds": 10,
                            "periodSeconds": 20,
                            "successThreshold": 1,
@@ -259,7 +259,7 @@
                                  "/opt/datagrid/bin/readinessProbe.sh"
                               ]
                            },
-                           "initialDelaySeconds": 7,
+                           "initialDelaySeconds": 17,
                            "timeoutSeconds": 10,
                            "periodSeconds": 20,
                            "successThreshold": 2,


### PR DESCRIPTION
With 0.5 CPU the readiness/liveness might not give proper results in 5 seconds.
Increasing it above 15 should improve stability.