### PR TITLE
ISPN-8559 Scaling up tests

### DIFF
--- a/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
@@ -1,17 +1,15 @@
 package org.infinispan.online.service.caching;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
 
 import io.fabric8.openshift.client.OpenShiftClient;
-
 import org.arquillian.cube.kubernetes.annotations.Named;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.online.service.endpoint.HotRodTester;
 import org.infinispan.online.service.endpoint.RESTTester;
+import org.infinispan.online.service.scaling.ScalingTester;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
 import org.infinispan.online.service.utils.ReadinessCheck;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Before;
@@ -19,7 +17,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static junit.framework.TestCase.assertNull;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNull;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
@@ -39,10 +41,12 @@ public class CachingServiceTest {
    ReadinessCheck readinessCheck = new ReadinessCheck();
    HotRodTester hotRodTester = new HotRodTester("caching-service");
    RESTTester restTester = new RESTTester();
+   ScalingTester scalingTester = new ScalingTester();
+   OpenShiftCommandlineClient commandlineClient = new OpenShiftCommandlineClient();
 
    @Before
    public void before() {
-      readinessCheck.waitUntilAllPodsAreReady(openShiftClient, 30, TimeUnit.SECONDS);
+      readinessCheck.waitUntilAllPodsAreReady(openShiftClient);
    }
 
    @Test
@@ -86,5 +90,10 @@ public class CachingServiceTest {
    @Test
    public void should_default_cache_be_protected_via_REST() throws IOException {
       restTester.testIfEndpointIsProtected(restService);
+   }
+
+   @Test
+   public void should_discover_new_cluster_members_when_scaling_up() {
+      scalingTester.testFormingAClusterAfterScalingUp("caching-service-app", hotRodService, commandlineClient, readinessCheck, openShiftClient, hotRodTester);
    }
 }

--- a/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
@@ -71,8 +71,12 @@ public class HotRodTester implements EndpointTester {
       return cachingService.getCache(cacheName);
    }
 
+   public int getNumberOfNodesInTheCluster(URL urlToService) {
+      return getDefaultCache(urlToService, true).getCacheTopologyInfo().getSegmentsPerServer().keySet().size();
+
+   }
+
    public RemoteCacheManager getRemoteCacheManager(URL urlToService, boolean authenticate) {
-      //given
       Configuration cachingServiceClientConfiguration = new ConfigurationBuilder()
          .addServer()
          .host(urlToService.getHost())

--- a/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
@@ -1,0 +1,28 @@
+package org.infinispan.online.service.scaling;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.infinispan.online.service.endpoint.HotRodTester;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
+import org.infinispan.online.service.utils.ReadinessCheck;
+
+import java.net.URL;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ScalingTester {
+
+   public void testFormingAClusterAfterScalingUp(String statefulSetName, URL hotRodService, OpenShiftCommandlineClient commandlineClient, ReadinessCheck readinessCheck, OpenShiftClient client, HotRodTester hotRodTester) {
+      //when
+      commandlineClient.scaleStatefulSet(statefulSetName, 2);
+      readinessCheck.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, 2, client);
+
+      int numberOfNodesInCluster = hotRodTester.getNumberOfNodesInTheCluster(hotRodService);
+
+      commandlineClient.scaleStatefulSet(statefulSetName, 1);
+      readinessCheck.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, 1, client);
+
+      //then
+      assertThat(numberOfNodesInCluster).isEqualTo(2);
+   }
+
+}

--- a/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
@@ -1,22 +1,22 @@
 package org.infinispan.online.service.sharedmemory;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.online.service.endpoint.HotRodTester;
 import org.infinispan.online.service.endpoint.RESTTester;
+import org.infinispan.online.service.scaling.ScalingTester;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
 import org.infinispan.online.service.utils.ReadinessCheck;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.fabric8.openshift.client.OpenShiftClient;
+import java.io.IOException;
+import java.net.URL;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
@@ -36,10 +36,12 @@ public class SharedMemoryServiceTest {
    ReadinessCheck readinessCheck = new ReadinessCheck();
    HotRodTester hotRodTester = new HotRodTester("shared-memory-service");
    RESTTester restTester = new RESTTester();
+   ScalingTester scalingTester = new ScalingTester();
+   OpenShiftCommandlineClient commandlineClient = new OpenShiftCommandlineClient();
 
    @Before
    public void before() {
-      readinessCheck.waitUntilAllPodsAreReady(openShiftClient, 30, TimeUnit.SECONDS);
+      readinessCheck.waitUntilAllPodsAreReady(openShiftClient);
    }
 
    @Test
@@ -60,5 +62,10 @@ public class SharedMemoryServiceTest {
    @Test
    public void should_default_cache_be_protected_via_REST() throws IOException {
       restTester.testIfEndpointIsProtected(restService);
+   }
+
+   @Test
+   public void should_discover_new_cluster_members_when_scaling_up() {
+      scalingTester.testFormingAClusterAfterScalingUp("shared-memory-service-app", hotRodService, commandlineClient, readinessCheck, openShiftClient, hotRodTester);
    }
 }

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/CommandlineClient.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/CommandlineClient.java
@@ -1,0 +1,52 @@
+package org.infinispan.online.service.utils;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class CommandlineClient {
+
+   class Result {
+      private final int errorCode;
+      private final String output;
+
+      public Result(int errorCode, String output) {
+         this.errorCode = errorCode;
+         this.output = output;
+      }
+
+      public int getErrorCode() {
+         return errorCode;
+      }
+
+      public String getOutput() {
+         return output;
+      }
+   }
+
+   public Result invokeAndReturnResult(String command) {
+      try {
+         ProcessBuilder pb = new ProcessBuilder(command.split(" "));
+
+         Process p = pb.start();
+         int resultCode = p.waitFor();
+         BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+         StringBuilder sb = new StringBuilder();
+         String line;
+         while ((line = br.readLine()) != null) {
+            sb.append(line).append("\n");
+         }
+         String output = sb.toString();
+         return new Result(resultCode, output);
+      } catch (Exception e) {
+         throw new IllegalStateException("Command " + command + " failed.", e);
+      }
+   }
+
+   public void invoke(String command) {
+      Result result = invokeAndReturnResult(command);
+      if (result.errorCode != 0) {
+         throw new IllegalStateException("Expected error code 0 but got " + result.errorCode + ". Output: " + result.output);
+      }
+   }
+}

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftCommandlineClient.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftCommandlineClient.java
@@ -1,0 +1,11 @@
+package org.infinispan.online.service.utils;
+
+public class OpenShiftCommandlineClient {
+
+   private CommandlineClient commandlineClient = new CommandlineClient();
+
+   public void scaleStatefulSet(String statefulSetName, int replicas) {
+      commandlineClient.invoke("oc scale statefulset " + statefulSetName + " --replicas=" + replicas);
+   }
+
+}

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
@@ -4,31 +4,64 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 
 public class ReadinessCheck {
 
-   public void waitUntilAllPodsAreReady(OpenShiftClient client, long timeout, TimeUnit unit) {
-      long endTime = TimeUnit.MILLISECONDS.convert(timeout, unit) + System.currentTimeMillis();
-      long backoffCounter = 0;
-      while (System.currentTimeMillis() - endTime < 0) {
-         Set<Pod> notReadyPods = getNotReadyPods(client);
-         if (notReadyPods.isEmpty()) {
-            break;
-         }
-         System.out.println("Some pods are not ready: " + notReadyPods);
-         LockSupport.parkNanos(++backoffCounter * 10_000_000);
-      }
+   private Waiter waiter = new Waiter();
+
+   public void waitUntilTargetNumberOfReplicasAreReady(String podPartialName, int replicas, OpenShiftClient client) {
+      waiter.waitFor(() -> getPodsWithName(podPartialName, client).size() == replicas);
+      waitUntilAllPodsAreReady(client);
+      System.out.println("All Pods are ready and target replicas looks good.");
    }
 
-   private Set<Pod> getNotReadyPods(OpenShiftClient client) {
+   public void waitUntilAllPodsAreReady(OpenShiftClient client) {
+      waiter.waitFor(() -> {
+         Set<Pod> allPods = getAllPods(client);
+         Set<Pod> notReadyPods = getNotReadyPods(allPods);
+         Set<Pod> readyPods = getReadyPods(allPods);
+
+         if (readyPods.size() + notReadyPods.size() == allPods.size()) {
+            return notReadyPods.isEmpty();
+         }
+
+         System.out.println("There is a mismatch between ready and not ready Pods. Skipping ready check.");
+         System.out.println("All Pods: " + allPods);
+         System.out.println("Not ready Pods: " + notReadyPods);
+         System.out.println("Ready Pods: " + readyPods);
+         return false;
+      });
+   }
+
+   private Set<Pod> getAllPods(OpenShiftClient client) {
       return client.pods().list().getItems().stream()
+         .collect(Collectors.toSet());
+   }
+
+   private Set<Pod> getNotReadyPods(Set<Pod> allPods) {
+      return allPods.stream()
          .filter(pod -> pod.getStatus().getConditions().stream()
             .filter(condition -> "Ready".equals(condition.getType()))
-            .filter(condition -> "False".equals(condition.getStatus()))
-            .findAny().isPresent())
+            .findFirst()
+            .map(readyCondition -> "False".equals(readyCondition.getStatus()))
+            .orElse(false)
+         ).collect(Collectors.toSet());
+   }
+
+   private Set<Pod> getReadyPods(Set<Pod> allPods) {
+      return allPods.stream()
+         .filter(pod -> pod.getStatus().getConditions().stream()
+               .filter(condition -> "Ready".equals(condition.getType()))
+               .findFirst()
+               .map(readyCondition -> "True".equals(readyCondition.getStatus()))
+               .orElse(false)
+         ).collect(Collectors.toSet());
+   }
+
+   private Set<Pod> getPodsWithName(String name, OpenShiftClient client) {
+      return client.pods().list().getItems().stream()
+         .filter(pod -> pod.getMetadata().getName().contains(name))
          .collect(Collectors.toSet());
    }
 }

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/Waiter.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/Waiter.java
@@ -1,0 +1,27 @@
+package org.infinispan.online.service.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+
+public class Waiter {
+
+   public static final int DEFAULT_TIMEOUT = 30;
+   public static final TimeUnit DEFAULT_TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+   public void waitFor(BooleanSupplier condition) {
+      waitFor(condition, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_UNIT);
+   }
+
+   public void waitFor(BooleanSupplier condition, long timeout, TimeUnit unit) {
+      long endTime = TimeUnit.MILLISECONDS.convert(timeout, unit) + System.currentTimeMillis();
+      long backoffCounter = 0;
+      while (System.currentTimeMillis() - endTime < 0) {
+         if (condition.getAsBoolean()) {
+            break;
+         }
+         LockSupport.parkNanos(++backoffCounter * 100_000_000);
+      }
+   }
+
+}

--- a/functional-tests/src/test/resources/destroy.sh
+++ b/functional-tests/src/test/resources/destroy.sh
@@ -6,6 +6,12 @@ oc get all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,
 echo "---- Docker PS ----"
 docker ps
 
+echo "---- Caching Service logs ----"
+oc logs caching-service-app-0
+
+echo "---- Shared Memory logs ----"
+oc logs shared-memory-service-app-0
+
 echo "---- Clearing up test resources ---"
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=caching-service || true
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=shared-memory-service || true

--- a/templates/caching-service.json
+++ b/templates/caching-service.json
@@ -292,7 +292,6 @@
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            },
                            "limits": {
-                              "cpu": "0.5",
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            }
                         }

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -300,7 +300,6 @@
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            },
                            "limits": {
-                              "cpu": "0.5",
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            }
                         }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8559

@ryanemerson @rmacior @mgencur - Just FYI - After this PR gets in, I plan to refactor the testsuite a bit. I don't like the way it scales for more complicated work like `ScalingTester#testFormingAClusterAfterScalingUp`. The number of parameter this method takes starts to be unmanageable.

My idea is to create:
* Testing harness class as a container for all of the stateless utility classes (like `ReadinessCheck` for example). Another way to do it would be to turn them into static utility methods. Both approaches have their advantages and disadvantages.
* Next, I plan to structure the testsuite as the following: HotRod/RestEndpoint - performs authentication and basic put/get methods. Those will be constructed with URL parameter (pointing to a Service). Next layer will be Testers - they will take Endpoint as parameters and will perform certain type of tests - like authentication, scaling or eviction checking. Those testers will be invoked directly from a test class.

Does that make sense to you?