### PR TITLE
Jenkinsfile now uses test-ci and clean-ci targets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,27 +22,15 @@ pipeline {
          }
       }
 
-      stage('Unit tests') {
-         steps {
-            script {
-               configFileProvider([configFile(fileId: 'maven-settings-with-prod', variable: 'MAVEN_SETTINGS')]) {
-                  script {
-                     sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" test-unit'
-                  }
-               }
-            }
-         }
-      }
-
-      stage('Functional and OpenShift tests') {
+      stage('Unit and Functional tests') {
          steps {
             script {
                configFileProvider([configFile(fileId: 'maven-settings-with-prod', variable: 'MAVEN_SETTINGS')]) {
                   script {
                      try {
-                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" start-openshift-with-catalog build-image push-image-to-local-openshift test-functional'
+                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" test-ci'
                      } finally {
-                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" stop-openshift clean-docker'
+                        sh 'make MVN_COMMAND="$MAVEN_HOME/bin/mvn -s $MAVEN_SETTINGS" clean-ci'
                      }
                   }
                }

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,11 @@ clean-docker:
 clean: clean-docker clean-maven stop-openshift
 .PHONY: clean
 
-test-ci: clean test-unit start-openshift-with-catalog build-image push-image-to-local-openshift test-functional clean
+test-ci: clean test-unit start-openshift-with-catalog build-image push-image-to-local-openshift test-functional
 .PHONY: test-ci
+
+clean-ci: clean-docker clean-templates-in-helper-namespace stop-openshift #avoid cleaning Maven as we need results to be reported by the job
+.PHONY: clean-ci
 
 apb-build:
 	(\


### PR DESCRIPTION
This one is required by https://github.com/jboss-container-images/jboss-dataservices-image/pull/30 and should be merged first so that https://github.com/jboss-container-images/jboss-dataservices-image/pull/30 can use it