### PR TITLE
ISPN-8611 Persistent volume names too long

### DIFF
--- a/templates/caching-service.json
+++ b/templates/caching-service.json
@@ -282,7 +282,7 @@
                         ],
                         "volumeMounts": [
                            {
-                              "name": "${APPLICATION_NAME}-data",
+                              "name": "srv-data",
                               "mountPath": "/opt/jboss/infinispan-server/standalone/data"
                            }
                         ],
@@ -309,7 +309,7 @@
             "volumeClaimTemplates": [
                {
                   "metadata": {
-                     "name": "${APPLICATION_NAME}-data"
+                     "name": "srv-data"
                   },
                   "spec": {
                      "accessModes": [

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -290,7 +290,7 @@
                         ],
                         "volumeMounts": [
                            {
-                              "name": "${APPLICATION_NAME}-data",
+                              "name": "srv-data",
                               "mountPath": "/opt/jboss/infinispan-server/standalone/data"
                            }
                         ],
@@ -317,7 +317,7 @@
             "volumeClaimTemplates": [
                {
                   "metadata": {
-                     "name": "${APPLICATION_NAME}-data"
+                     "name": "srv-data"
                   },
                   "spec": {
                      "accessModes": [


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8611

The APPLICATION_NAME is redundant because the persistent volume claim as well as an additional service already have the application name included in their name:
* srv-data-shared-memory-service-app-0    (volume claim)
* glusterfs-dynamic-srv-data-shared-memory-service-app-0 (additional service's name when using GlusterFS)