### PR TITLE
Encryption support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build-image:
 	( \
 		virtualenv ~/concreate; \
 		source ~/concreate/bin/activate; \
-		pip install -U concreate==1.3.0; \
+		pip install -U concreate==1.3.4; \
 		$(CONCREATE_CMD) \
 		deactivate; \
 	)

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ clean-maven:
 clean-docker:
 	sudo docker rmi $(_IMAGE) || true
 	sudo docker rmi $(_APB_IMAGE) || true
+	rm -rf target-docker
 .PHONY: clean-docker
 
 clean: clean-docker clean-maven stop-openshift

--- a/Makefile
+++ b/Makefile
@@ -135,14 +135,16 @@ clear-templates:
 .PHONY: clear-templates
 
 test-caching-service-manually:
-	oc process caching-service -p NAMESPACE=$(shell oc project -q) -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test -p IMAGE=$(_IMAGE) | oc create -f -
+	oc process caching-service -p NAMESPACE=$(shell oc project -q) -p APPLICATION_USER=test \
+	-p APPLICATION_USER_PASSWORD=test -p IMAGE=$(_IMAGE) -p KEYSTORE_PASSWORD=test99 | oc create -f -
 	oc expose svc/caching-service-app-http || true
 	oc expose svc/caching-service-app-hotrod || true
 	oc get routes
 .PHONY: test-caching-service-manually
 
 test-shared-memory-service-manually:
-	oc process shared-memory-service -p NAMESPACE=$(shell oc project -q) -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test -p IMAGE=$(_IMAGE)  | oc create -f -
+	oc process shared-memory-service -p NAMESPACE=$(shell oc project -q) -p APPLICATION_USER=test \
+	-p APPLICATION_USER_PASSWORD=test -p IMAGE=$(_IMAGE)  -p KEYSTORE_PASSWORD=test99 | oc create -f -
 	oc expose svc/shared-memory-service-app-http || true
 	oc expose svc/shared-memory-service-app-hotrod || true
 	oc get routes

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -15,7 +15,7 @@
       <openshift-client.version>3.0.3</openshift-client.version>
       <arquillian-cube-openshift.version>1.10.0</arquillian-cube-openshift.version>
       <assertj-core.version>3.8.0</assertj-core.version>
-      <rest-assured.version>3.0.5</rest-assured.version>
+      <jetty-client.version>9.4.8.v20171121 </jetty-client.version>
       <version.chameleon>1.0.0.Beta2</version.chameleon>
       <org.apache.maven.user-settings></org.apache.maven.user-settings>
    </properties>
@@ -70,9 +70,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>io.rest-assured</groupId>
-         <artifactId>rest-assured</artifactId>
-         <version>${rest-assured.version}</version>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-client</artifactId>
+         <version>${jetty-client.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/functional-tests/pom.xml
+++ b/functional-tests/pom.xml
@@ -13,7 +13,7 @@
       <version.arquillian.bom>1.1.8.Final</version.arquillian.bom>
       <version.infinispan.bom>8.5.0.DR2-redhat-1</version.infinispan.bom>
       <openshift-client.version>3.0.3</openshift-client.version>
-      <arquillian-cube-openshift.version>1.9.0</arquillian-cube-openshift.version>
+      <arquillian-cube-openshift.version>1.10.0</arquillian-cube-openshift.version>
       <assertj-core.version>3.8.0</assertj-core.version>
       <rest-assured.version>3.0.5</rest-assured.version>
       <version.chameleon>1.0.0.Beta2</version.chameleon>

--- a/functional-tests/src/test/java/org/infinispan/online/service/caching/BasicInProjectTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/caching/BasicInProjectTest.java
@@ -1,7 +1,10 @@
 package org.infinispan.online.service.caching;
 
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.openshift.client.OpenShiftClient;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
@@ -11,6 +14,7 @@ import org.infinispan.online.service.utils.DeploymentHelper;
 import org.infinispan.online.service.utils.OpenShiftClientCreator;
 import org.infinispan.online.service.utils.OpenShiftHandle;
 import org.infinispan.online.service.utils.ReadinessCheck;
+import org.infinispan.online.service.utils.TrustStore;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -20,11 +24,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
@@ -32,8 +33,8 @@ public class BasicInProjectTest {
 
    URL hotRodService;
    URL restService;
-   HotRodTester hotRodTester = new HotRodTester("caching-service");
-   RESTTester restTester = new RESTTester();
+   HotRodTester hotRodTester = new HotRodTester("caching-service", "/var/run/secrets/java.io/keystores");
+   RESTTester restTester = new RESTTester("caching-service", "/var/run/secrets/java.io/keystores");
 
    ReadinessCheck readinessCheck = new ReadinessCheck();
    OpenShiftClient client = OpenShiftClientCreator.getClient();
@@ -54,6 +55,7 @@ public class BasicInProjectTest {
       readinessCheck.waitUntilAllPodsAreReady(client);
       hotRodService = handle.getServiceWithName("caching-service-app-hotrod");
       restService = handle.getServiceWithName("caching-service-app-http");
+      TrustStore.create("/var/run/secrets/java.io/keystores", "caching-service", client);
    }
 
    @Test

--- a/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
@@ -1,12 +1,17 @@
 package org.infinispan.online.service.endpoint;
 
+import static junit.framework.TestCase.assertNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.online.service.utils.TestObjectCreator.generateConstBytes;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import io.fabric8.kubernetes.api.model.Pod;
+
 import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -14,28 +19,29 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.SaslQop;
 import org.infinispan.online.service.utils.TestObjectCreator;
+import org.infinispan.online.service.utils.TrustStore;
 
-import static junit.framework.TestCase.assertNull;
-import static org.infinispan.online.service.utils.TestObjectCreator.generateConstBytes;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import io.fabric8.kubernetes.api.model.Pod;
 
 public class HotRodTester implements EndpointTester {
 
-   private final String serverName;
+   private final String serviceName;
+   private final String trustStorePath;
    private String hotRodKey = "hotRodKey";
 
-   public HotRodTester(String serverName) {
-      this.serverName = serverName;
+   public HotRodTester(String serviceName, String trustStoreDir) {
+      this.serviceName = serviceName;
+      this.trustStorePath = TrustStore.getPath(trustStoreDir, serviceName);
    }
 
    public void testBasicEndpointCapabilities(URL urlToService) {
       testBasicEndpointCapabilities(urlToService, true);
    }
 
-   public void testBasicEndpointCapabilities(URL urlToService, boolean authenticate) {
+   private void testBasicEndpointCapabilities(URL urlToService, boolean authenticate) {
       //given
-      RemoteCache<String, String> defaultCache = getDefaultCache(urlToService, authenticate);
+      RemoteCacheManager cachingService = getRemoteCacheManager(urlToService, authenticate);
+      RemoteCache<String, String> defaultCache = cachingService.getCache();
 
       //when
       defaultCache.put("should_default_cache_be_accessible_via_hot_rod", "test");
@@ -48,7 +54,7 @@ public class HotRodTester implements EndpointTester {
    @Override
    public void testPutPerformance(URL urlToService, long timeout, TimeUnit timeUnit) {
       //given
-      RemoteCache<String, String> defaultCache = getDefaultCache(urlToService, true);
+      RemoteCache<String, String> defaultCache = getDefaultCache(urlToService);
       long endTime = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
       TestObjectCreator testObjectCreator = new TestObjectCreator();
 
@@ -66,7 +72,7 @@ public class HotRodTester implements EndpointTester {
    }
 
    public void testPodsVisible(URL urlToService, List<Pod> pods) {
-      RemoteCache<String, String> defaultCache = getDefaultCache(urlToService, false);
+      RemoteCache<String, String> defaultCache = getDefaultCache(urlToService);
       CacheTopologyInfo topology = defaultCache.getCacheTopologyInfo();
 
       List<String> podIPs = pods.stream()
@@ -81,40 +87,47 @@ public class HotRodTester implements EndpointTester {
       assertThat(cacheNodeIPs).isEqualTo(podIPs);
    }
 
-   public RemoteCache<String, String> getDefaultCache(URL urlToService, boolean authenticate) {
-      RemoteCacheManager cachingService = getRemoteCacheManager(urlToService, authenticate);
+   private RemoteCache<String, String> getDefaultCache(URL urlToService) {
+      RemoteCacheManager cachingService = getRemoteCacheManager(urlToService);
       return cachingService.getCache();
    }
 
-   public RemoteCache<String, String> getNamedCache(URL urlToService, String cacheName, boolean authenticate) {
-      RemoteCacheManager cachingService = getRemoteCacheManager(urlToService, authenticate);
+   public RemoteCache<String, String> getNamedCache(URL urlToService, String cacheName) {
+      RemoteCacheManager cachingService = getRemoteCacheManager(urlToService);
       return cachingService.getCache(cacheName);
    }
 
    public int getNumberOfNodesInTheCluster(URL urlToService) {
-      return getDefaultCache(urlToService, true).getCacheTopologyInfo().getSegmentsPerServer().keySet().size();
-
+      return getDefaultCache(urlToService).getCacheTopologyInfo().getSegmentsPerServer().keySet().size();
    }
 
-   public RemoteCacheManager getRemoteCacheManager(URL urlToService, boolean authenticate) {
+   private RemoteCacheManager getRemoteCacheManager(URL urlToService) {
+      return getRemoteCacheManager(urlToService, true);
+   }
+
+   private RemoteCacheManager getRemoteCacheManager(URL urlToService, boolean authenticate) {
       Configuration cachingServiceClientConfiguration = new ConfigurationBuilder()
          .addServer()
          .host(urlToService.getHost())
          .port(urlToService.getPort())
-         .security().authentication().enabled(authenticate)
+         .security()
+         .ssl().enabled(true)
+         .trustStoreFileName(trustStorePath)
+         .trustStorePassword(TrustStore.TRUSTSTORE_PASSWORD)
+         .authentication().enabled(authenticate)
          .username("test")
          .password("test")
          .realm("ApplicationRealm")
          .saslMechanism("DIGEST-MD5")
          .saslQop(SaslQop.AUTH)
-         .serverName(serverName)
+         .serverName(serviceName)
          .build();
 
       return new RemoteCacheManager(cachingServiceClientConfiguration);
    }
 
    public void putGetTest(URL hotRodService) {
-      RemoteCacheManager cachingService = getRemoteCacheManager(hotRodService, true);
+      RemoteCacheManager cachingService = getRemoteCacheManager(hotRodService);
 
       stringPutGetTest(cachingService);
       stringUpdateGetTest(cachingService);
@@ -175,7 +188,7 @@ public class HotRodTester implements EndpointTester {
 
    public void evictionTest(URL hotRodService) {
       //given
-      RemoteCacheManager cachingService = getRemoteCacheManager(hotRodService, true);
+      RemoteCacheManager cachingService = getRemoteCacheManager(hotRodService);
       RemoteCache<String, byte[]> byteArrayCache = cachingService.getCache();
       byte[] randomValue = generateConstBytes(1024*1024);
       int currentCacheSize = -1;

--- a/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/sharedmemory/SharedMemoryServiceTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.online.service.sharedmemory;
 
-import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
@@ -10,28 +10,31 @@ import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.online.service.endpoint.HotRodTester;
 import org.infinispan.online.service.endpoint.RESTTester;
 import org.infinispan.online.service.scaling.ScalingTester;
-import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
 import org.infinispan.online.service.utils.OpenShiftClientCreator;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
 import org.infinispan.online.service.utils.OpenShiftHandle;
 import org.infinispan.online.service.utils.ReadinessCheck;
+import org.infinispan.online.service.utils.TrustStore;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.net.MalformedURLException;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
 @RunAsClient
 public class SharedMemoryServiceTest {
 
+   private static final String SERVICE_NAME = "shared-memory-service";
+
    URL hotRodService;
    URL restService;
 
    ReadinessCheck readinessCheck = new ReadinessCheck();
-   HotRodTester hotRodTester = new HotRodTester("shared-memory-service");
-   RESTTester restTester = new RESTTester();
+   HotRodTester hotRodTester = new HotRodTester(SERVICE_NAME, "target");
+   RESTTester restTester = new RESTTester(SERVICE_NAME, "target");
    ScalingTester scalingTester = new ScalingTester();
    OpenShiftCommandlineClient commandlineClient = new OpenShiftCommandlineClient();
    OpenShiftClient client;
@@ -43,6 +46,7 @@ public class SharedMemoryServiceTest {
       readinessCheck.waitUntilAllPodsAreReady(client);
       hotRodService = handle.getServiceWithName("shared-memory-service-app-hotrod");
       restService = handle.getServiceWithName("shared-memory-service-app-http");
+      TrustStore.create("target", SERVICE_NAME, client);
    }
 
    @Test

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/DeploymentHelper.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/DeploymentHelper.java
@@ -1,8 +1,8 @@
 package org.infinispan.online.service.utils;
 
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-
 import java.io.File;
+
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 public class DeploymentHelper {
 
@@ -11,7 +11,7 @@ public class DeploymentHelper {
          .resolve("org.infinispan:infinispan-client-hotrod",
             "io.fabric8:openshift-client",
             "org.assertj:assertj-core",
-            "io.rest-assured:rest-assured")
+            "org.eclipse.jetty:jetty-client")
          .withTransitivity().asFile();
    }
 }

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class OpenShiftHandle {
 
-   private static final String HTTP_PROTOCOL = "http";
+   private static final String HTTP_PROTOCOL = "https";
 
    private OpenShiftClient client;
 

--- a/functional-tests/src/test/java/org/infinispan/online/service/utils/TrustStore.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/utils/TrustStore.java
@@ -1,0 +1,43 @@
+package org.infinispan.online.service.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.util.Base64;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+
+public class TrustStore {
+   public static final char[] TRUSTSTORE_PASSWORD = "test99".toCharArray();
+
+   public static String getPath(String baseDir, String serviceName) {
+      Path currentRelativePath = Paths.get(baseDir);
+      String absolutePath = currentRelativePath.toAbsolutePath().toString();
+      return String.format("%s/%s.jks", absolutePath, serviceName);
+   }
+
+   public static KeyStore create(String baseDir, String serviceName, OpenShiftClient client) {
+      String certSecret = client.secrets().withName("service-certs").get().getData().get("tls.crt");
+      assert certSecret != null;
+
+      try (InputStream input = Base64.getDecoder().wrap(new ByteArrayInputStream(certSecret.getBytes(StandardCharsets.UTF_8)));
+           FileOutputStream output = new FileOutputStream(getPath(baseDir, serviceName))) {
+
+         KeyStore trustStore = KeyStore.getInstance("JKS");
+         CertificateFactory cf = CertificateFactory.getInstance("X.509");
+         Certificate certificate = cf.generateCertificate(input);
+         trustStore.load(null, null);
+         trustStore.setCertificateEntry(serviceName, certificate);
+         trustStore.store(output, TRUSTSTORE_PASSWORD);
+         return trustStore;
+      } catch (Exception e) {
+         throw new IllegalStateException(e);
+      }
+   }
+}

--- a/functional-tests/src/test/resources/arquillian.xml
+++ b/functional-tests/src/test/resources/arquillian.xml
@@ -34,6 +34,10 @@
       <property name="proxiedContainerPorts">testrunner:9990</property>
       <!-- Fetch the logs from Openshift and pods, and save them into target/surefire-reports -->
       <property name="logs.copy">true</property>
+
+      <!-- Set these two props to false if you don't want the server to be destroyed after the tests finish -->
+      <property name="namespace.cleanup.enabled">true</property>
+      <property name="namespace.destroy.enabled">true</property>
    </extension>
 
    <container qualifier="testrunner" mode="suite" default="true">

--- a/functional-tests/src/test/resources/destroy.sh
+++ b/functional-tests/src/test/resources/destroy.sh
@@ -3,14 +3,23 @@
 echo "---- Printing out test resources ----"
 oc get all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts
 
+echo "---- Describe Pods ----"
+oc describe pods
+
 echo "---- Docker PS ----"
 docker ps
 
 echo "---- Caching Service logs ----"
 oc logs caching-service-app-0
+oc logs caching-service-app-0 -c pem-to-keystore
 
 echo "---- Shared Memory logs ----"
 oc logs shared-memory-service-app-0
+oc logs shared-memory-service-app-0 -c pem-to-keystore
+
+echo "---- Test Runner logs ----"
+oc logs testrunner
+oc logs testrunner -c pem-to-truststore
 
 echo "---- Clearing up test resources ---"
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=caching-service || true

--- a/functional-tests/src/test/resources/eap7-testrunner.json
+++ b/functional-tests/src/test/resources/eap7-testrunner.json
@@ -55,9 +55,54 @@
                },
                {
                   "name" : "DEBUG",
-                  "value" : "false"
+                  "value" : "true"
+               }
+            ],
+            "volumeMounts": [
+               {
+                  "name": "truststore-volume",
+                  "mountPath": "/var/run/secrets/java.io/keystores"
                }
             ]
+         }
+      ],
+      "initContainers": [
+         {
+            "name": "pem-to-truststore",
+            "image": "${DOCKER_REGISTRY_REDHAT}redhat-sso-7/sso71-openshift:1.1-16",
+            "env": [
+               {
+                  "name": "CA_BUNDLE",
+                  "value": "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+               },
+               {
+                  "name": "TRUSTSTORE_JKS",
+                  "value": "/var/run/secrets/java.io/keystores/caching-service.jks"
+               },
+               {
+                  "name": "TRUSTSTORE_PASSWORD",
+                  "value": "test99"
+               }
+            ],
+            "command": [
+               "/bin/bash"
+            ],
+            "args": [
+               "-c",
+               "rm -f $TRUSTSTORE_JKS && csplit -z -f crt- $CA_BUNDLE '/-----BEGIN CERTIFICATE-----/' '{*}' && for file in crt-*; do keytool -import -noprompt -keystore $TRUSTSTORE_JKS -file $file -storepass $TRUSTSTORE_PASSWORD -alias service-$file; done"
+            ],
+            "volumeMounts": [
+               {
+                  "name": "truststore-volume",
+                  "mountPath": "/var/run/secrets/java.io/keystores"
+               }
+            ]
+         }
+      ],
+      "volumes": [
+         {
+            "name": "truststore-volume",
+            "emptyDir": {}
          }
       ]
    }

--- a/functional-tests/src/test/resources/setup.sh
+++ b/functional-tests/src/test/resources/setup.sh
@@ -16,5 +16,8 @@ echo "Using image $IMAGE_NAME"
 oc create -f ../templates/caching-service.json
 oc create -f ../templates/shared-memory-service.json
 
-oc process caching-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -
-oc process shared-memory-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -
+oc process caching-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test \
+-p APPLICATION_USER_PASSWORD=test -p KEYSTORE_PASSWORD=test99 | oc create -f -
+
+oc process shared-memory-service -p NAMESPACE=$(oc project -q) -p IMAGE=${IMAGE_NAME} \
+-p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test -p KEYSTORE_PASSWORD=test99 | oc create -f -

--- a/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/caching-service.cli
+++ b/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/caching-service.cli
@@ -13,6 +13,12 @@ end-if
 /subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/authentication=AUTHENTICATION:add(security-realm=ApplicationRealm)
 /subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/authentication=AUTHENTICATION/sasl=SASL:add(server-name=caching-service, mechanisms=[DIGEST-MD5], qop=[auth])
 
+# Add keystore
+/core-service=management/security-realm=ApplicationRealm/server-identity=ssl:add(keystore-path=$keystore_file, keystore-password=$keystore_password)
+# Write encryption
+/subsystem=datagrid-infinispan-endpoint/rest-connector=rest-connector/encryption=ENCRYPTION:add(security-realm=ApplicationRealm)
+/subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/encryption=ENCRYPTION:add(security-realm=ApplicationRealm)
+
 /subsystem=datagrid-infinispan/cache-container=clustered/configurations=CONFIGURATIONS/distributed-cache-configuration=caching-service/memory=OFF-HEAP:add(size=$eviction_total_memory_bytes, eviction=MEMORY)
 
 # Remove memcached as it is not secured

--- a/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
+++ b/modules/os-datagrid-online-services-configuration/src/main/bash/profiles/shared-memory-service.cli
@@ -17,6 +17,12 @@ end-if
 /subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/authentication=AUTHENTICATION:add(security-realm=ApplicationRealm)
 /subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/authentication=AUTHENTICATION/sasl=SASL:add(server-name=shared-memory-service, mechanisms=[DIGEST-MD5], qop=[auth])
 
+# Add keystore
+/core-service=management/security-realm=ApplicationRealm/server-identity=ssl:add(keystore-path=$keystore_file, keystore-password=$keystore_password)
+# Write encryption
+/subsystem=datagrid-infinispan-endpoint/rest-connector=rest-connector/encryption=ENCRYPTION:add(security-realm=ApplicationRealm)
+/subsystem=datagrid-infinispan-endpoint/hotrod-connector=hotrod-connector/encryption=ENCRYPTION:add(security-realm=ApplicationRealm)
+
 # Remove memcached as it is not secured
 if (outcome == success) of /subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:read-resource
    /subsystem=datagrid-infinispan/cache-container=clustered/distributed-cache=memcachedCache:remove

--- a/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/CachingServiceConfigurationTest.java
+++ b/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/CachingServiceConfigurationTest.java
@@ -7,7 +7,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.assertj.core.util.Maps;
 import org.infinispan.online.service.caching.assertions.ResultAssertion;
 import org.infinispan.online.service.caching.assertions.XmlAssertion;
 import org.infinispan.online.service.caching.util.ConfigurationScriptInvoker;
@@ -25,12 +24,16 @@ public class CachingServiceConfigurationTest {
    Path servicesXml = testServerLocator.locateServer().resolve("standalone/configuration/services.xml");
    Path jbossHome = testServerLocator.locateServer();
 
-   Map<String, String> requiredScriptParameters = Maps.newHashMap("eviction_total_memory_bytes", "1");
+   Map<String, String> requiredScriptParameters = new HashMap<>();
    Map<String, String> requiredEnvVars = new HashMap<>();
 
    public CachingServiceConfigurationTest() {
       requiredEnvVars.put("APPLICATION_USER", "test");
       requiredEnvVars.put("APPLICATION_USER_PASSWORD", "test");
+
+      requiredScriptParameters.put("eviction_total_memory_bytes", "1");
+      requiredScriptParameters.put("keystore_file", "test");
+      requiredScriptParameters.put("keystore_password", "test");
    }
 
    @Before

--- a/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/SharedMemoryServiceConfigurationTest.java
+++ b/modules/os-datagrid-online-services-configuration/src/test/java/org/infinispan/online/service/caching/SharedMemoryServiceConfigurationTest.java
@@ -7,7 +7,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.assertj.core.util.Maps;
 import org.infinispan.online.service.caching.assertions.ResultAssertion;
 import org.infinispan.online.service.caching.assertions.XmlAssertion;
 import org.infinispan.online.service.caching.util.ConfigurationScriptInvoker;
@@ -25,12 +24,16 @@ public class SharedMemoryServiceConfigurationTest {
    Path servicesXml = testServerLocator.locateServer().resolve("standalone/configuration/services.xml");
    Path jbossHome = testServerLocator.locateServer();
 
-   Map<String, String> requiredScriptParameters = Maps.newHashMap("num_owners", "3");
+   Map<String, String> requiredScriptParameters = new HashMap<>();
    Map<String, String> requiredEnvVars = new HashMap<>();
 
    public SharedMemoryServiceConfigurationTest() {
       requiredEnvVars.put("APPLICATION_USER", "test");
       requiredEnvVars.put("APPLICATION_USER_PASSWORD", "test");
+
+      requiredScriptParameters.put("num_owners", "3");
+      requiredScriptParameters.put("keystore_file", "test");
+      requiredScriptParameters.put("keystore_password", "test");
    }
 
 

--- a/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
+++ b/modules/os-datagrid-online-services-launch/added/datagrid-online-services.sh
@@ -26,7 +26,9 @@ CONFIGURE_SCRIPTS=(
 
 source $JBOSS_HOME/bin/launch/configure.sh
 
-$JBOSS_HOME/bin/launch/jdg-online-configuration.sh --profile $PROFILE "eviction_total_memory_bytes=$EVICTION_TOTAL_MEMORY_B" "num_owners=${NUMBER_OF_OWNERS}"
+$JBOSS_HOME/bin/launch/jdg-online-configuration.sh --profile $PROFILE "eviction_total_memory_bytes=$EVICTION_TOTAL_MEMORY_B" \
+"num_owners=${NUMBER_OF_OWNERS}" "keystore_file=${KEYSTORE_FILE}" "keystore_password=${KEYSTORE_PASSWORD}"
+
 if [[ $? -ne 0 ]]; then
     echo "ERROR: Service configuration failed, TERMINATING."
     exit 1

--- a/templates/caching-service.json
+++ b/templates/caching-service.json
@@ -61,7 +61,8 @@
          "kind": "Service",
          "metadata": {
             "annotations": {
-               "description": "Headless service for StatefulSets"
+               "description": "Headless service for StatefulSets",
+               "service.alpha.openshift.io/serving-cert-secret-name": "service-certs"
             },
             "labels": {
                "application": "${APPLICATION_NAME}"
@@ -174,10 +175,6 @@
                               "value": "CACHING-SERVICE"
                            },
                            {
-                              "name": "PROFILE",
-                              "value": "CACHING-SERVICE"
-                           },
-                           {
                               "name": "OPENSHIFT_KUBE_PING_LABELS",
                               "value": "application=${APPLICATION_NAME}"
                            },
@@ -188,6 +185,14 @@
                                     "fieldPath": "metadata.namespace"
                                  }
                               }
+                           },
+                           {
+                              "name": "KEYSTORE_FILE",
+                              "value": "/var/run/secrets/java.io/keystores/${APPLICATION_NAME}.jks"
+                           },
+                           {
+                              "name": "KEYSTORE_PASSWORD",
+                              "value": "${KEYSTORE_PASSWORD}"
                            },
                            {
                               "name": "APPLICATION_USER",
@@ -255,6 +260,10 @@
                            {
                               "name": "srv-data",
                               "mountPath": "/opt/jboss/infinispan-server/standalone/data"
+                           },
+                           {
+                              "name": "srv-data",
+                              "mountPath": "/var/run/secrets/java.io/keystores"
                            }
                         ],
                         "resources": {
@@ -265,6 +274,59 @@
                            "limits": {
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            }
+                        }
+                     }
+                  ],
+                  "initContainers": [
+                     {
+                        "name": "pem-to-keystore",
+                        "image": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1-16",
+                        "env": [
+                           {
+                              "name": "TLS_KEY_FILE",
+                              "value": "/var/run/secrets/openshift.io/serviceaccount/tls.key"
+                           },
+                           {
+                              "name": "CRT_FILE",
+                              "value": "/var/run/secrets/openshift.io/serviceaccount/tls.crt"
+                           },
+                           {
+                              "name": "KEYSTORE_PKCS12",
+                              "value": "/var/run/secrets/java.io/keystores/keystore.pkcs12"
+                           },
+                           {
+                              "name": "KEYSTORE_FILE",
+                              "value": "/var/run/secrets/java.io/keystores/${APPLICATION_NAME}.jks"
+                           },
+                           {
+                              "name": "KEYSTORE_PASSWORD",
+                              "value": "${KEYSTORE_PASSWORD}"
+                           }
+                        ],
+                        "command": [
+                           "/bin/bash"
+                        ],
+                        "args": [
+                           "-c",
+                           "rm -f $KEYSTORE_FILE && openssl pkcs12 -export -inkey $TLS_KEY_FILE -in $CRT_FILE -out $KEYSTORE_PKCS12 -password pass:$KEYSTORE_PASSWORD && keytool -importkeystore -noprompt -srckeystore $KEYSTORE_PKCS12 -srcstoretype pkcs12 -destkeystore $KEYSTORE_FILE -storepass $KEYSTORE_PASSWORD -srcstorepass $KEYSTORE_PASSWORD"
+                        ],
+                        "volumeMounts": [
+                           {
+                              "name": "srv-data",
+                              "mountPath": "/var/run/secrets/java.io/keystores"
+                           },
+                           {
+                              "name": "service-certs",
+                              "mountPath": "/var/run/secrets/openshift.io/serviceaccount"
+                           }
+                        ]
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "name": "service-certs",
+                        "secret": {
+                           "secretName": "service-certs"
                         }
                      }
                   ],
@@ -342,6 +404,13 @@
          "name": "APPLICATION_USER_PASSWORD",
          "displayName": "Client Password",
          "description": "Password for client applications",
+         "generate": "expression",
+         "from": "[a-zA-Z0-9]{16}"
+      },
+      {
+         "name": "KEYSTORE_PASSWORD",
+         "displayName": "Java Keystore Password",
+         "description": "Password for the created java keystore",
          "generate": "expression",
          "from": "[a-zA-Z0-9]{16}"
       }

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -61,7 +61,8 @@
          "kind": "Service",
          "metadata": {
             "annotations": {
-               "description": "Headless service for StatefulSets"
+               "description": "Headless service for StatefulSets",
+               "service.alpha.openshift.io/serving-cert-secret-name": "service-certs"
             },
             "labels": {
                "application": "${APPLICATION_NAME}"
@@ -186,6 +187,14 @@
                               }
                            },
                            {
+                              "name": "KEYSTORE_FILE",
+                              "value": "/var/run/secrets/java.io/keystores/${APPLICATION_NAME}.jks"
+                           },
+                           {
+                              "name": "KEYSTORE_PASSWORD",
+                              "value": "${KEYSTORE_PASSWORD}"
+                           },
+                           {
                               "name": "NODE_NAME",
                               "valueFrom": {
                                  "fieldRef": {
@@ -263,6 +272,10 @@
                            {
                               "name": "srv-data",
                               "mountPath": "/opt/jboss/infinispan-server/standalone/data"
+                           },
+                           {
+                              "name": "srv-data",
+                              "mountPath": "/var/run/secrets/java.io/keystores"
                            }
                         ],
                         "resources": {
@@ -273,6 +286,59 @@
                            "limits": {
                               "memory": "${TOTAL_CONTAINER_MEM}Mi"
                            }
+                        }
+                     }
+                  ],
+                  "initContainers": [
+                     {
+                        "name": "pem-to-keystore",
+                        "image": "registry.access.redhat.com/redhat-sso-7/sso71-openshift:1.1-16",
+                        "env": [
+                           {
+                              "name": "TLS_KEY_FILE",
+                              "value": "/var/run/secrets/openshift.io/serviceaccount/tls.key"
+                           },
+                           {
+                              "name": "CRT_FILE",
+                              "value": "/var/run/secrets/openshift.io/serviceaccount/tls.crt"
+                           },
+                           {
+                              "name": "KEYSTORE_PKCS12",
+                              "value": "/var/run/secrets/java.io/keystores/keystore.pkcs12"
+                           },
+                           {
+                              "name": "KEYSTORE_FILE",
+                              "value": "/var/run/secrets/java.io/keystores/${APPLICATION_NAME}.jks"
+                           },
+                           {
+                              "name": "KEYSTORE_PASSWORD",
+                              "value": "${KEYSTORE_PASSWORD}"
+                           }
+                        ],
+                        "command": [
+                           "/bin/bash"
+                        ],
+                        "args": [
+                           "-c",
+                           "rm -f $KEYSTORE_FILE && openssl pkcs12 -export -inkey $TLS_KEY_FILE -in $CRT_FILE -out $KEYSTORE_PKCS12 -password pass:$KEYSTORE_PASSWORD && keytool -importkeystore -noprompt -srckeystore $KEYSTORE_PKCS12 -srcstoretype pkcs12 -destkeystore $KEYSTORE_FILE -storepass $KEYSTORE_PASSWORD -srcstorepass $KEYSTORE_PASSWORD"
+                        ],
+                        "volumeMounts": [
+                           {
+                              "name": "srv-data",
+                              "mountPath": "/var/run/secrets/java.io/keystores"
+                           },
+                           {
+                              "name": "service-certs",
+                              "mountPath": "/var/run/secrets/openshift.io/serviceaccount"
+                           }
+                        ]
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "name": "service-certs",
+                        "secret": {
+                           "secretName": "service-certs"
                         }
                      }
                   ],
@@ -309,12 +375,14 @@
       {
          "description": "Namespace for the application. Note: The namespace is required for creating proper RoleBindings. Specifying wrong namespace will prevent cluster from forming.",
          "name": "NAMESPACE",
+         "displayName": "Namespace",
          "required": true,
          "value": "myproject"
       },
       {
          "description": "The name for the application.",
          "name": "APPLICATION_NAME",
+         "displayName": "Application Name",
          "required": true,
          "value": "shared-memory-service-app"
       },
@@ -327,17 +395,20 @@
       {
          "description": "Number of instances in the cluster.",
          "name": "NUMBER_OF_INSTANCES",
+         "displayName": "Number of Instances",
          "required": true,
          "value": "1"
       },
       {
         "description": "Number of replicas for each cache entry in the cluster.",
+        "displayNme": "Number of owners",
         "name": "NUMBER_OF_OWNERS",
         "required": false,
         "value": "2"
       },
       {
          "description": "Total container memory in MiB.",
+         "displayName": "Total Memory",
          "name": "TOTAL_CONTAINER_MEM",
          "required": false,
          "value": "512"
@@ -352,6 +423,13 @@
          "name": "APPLICATION_USER_PASSWORD",
          "displayName": "Client Password",
          "description": "Password for client applications",
+         "generate": "expression",
+         "from": "[a-zA-Z0-9]{16}"
+      },
+      {
+         "name": "KEYSTORE_PASSWORD",
+         "displayName": "Java Keystore Password",
+         "description": "Password for the created java keystore",
          "generate": "expression",
          "from": "[a-zA-Z0-9]{16}"
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8475
https://issues.jboss.org/browse/ISPN-8476

@mgencur @slaskawi I was having serious issues getting RestAssured to play nice with SSL and it seems that several other users have had similar issues. So to get around these limitations I have refactored `RESTTester` to utilise the jetty http-client instead. It's slightly more verbose than RestAssured, but it works well.