### PR TITLE
ISPN-8536 Fix should_not_blow_up_because_of_oom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DEV_IMAGE_ORG = jboss-dataservices
 DOCKER_REGISTRY_ENGINEERING =
 DOCKER_REGISTRY_REDHAT =
 DEV_IMAGE_NAME = datagrid-online-services-dev
+ADDITIONAL_ARGUMENTS =
 
 CE_DOCKER = $(shell docker version | grep Version | head -n 1 | grep -e "-ce")
 ifneq ($(CE_DOCKER),)
@@ -102,11 +103,11 @@ push-image-to-local-openshift: _add_openshift_push_permissions _login_to_openshi
 .PHONY: push-image-to-local-openshift
 
 test-functional:
-	$(MVN_COMMAND) -Dimage=$(_IMAGE) -Dkubernetes.auth.token=$(shell oc whoami -t) -DDOCKER_REGISTRY_REDHAT=$(DOCKER_REGISTRY_REDHAT) clean test -f functional-tests/pom.xml
+	$(MVN_COMMAND) -Dimage=$(_IMAGE) -Dkubernetes.auth.token=$(shell oc whoami -t) -DDOCKER_REGISTRY_REDHAT=$(DOCKER_REGISTRY_REDHAT) clean test -f functional-tests/pom.xml $(ADDITIONAL_ARGUMENTS)
 .PHONY: test-functional
 
 test-unit:
-	$(MVN_COMMAND) clean test -f modules/os-datagrid-online-services-configuration/pom.xml
+	$(MVN_COMMAND) clean test -f modules/os-datagrid-online-services-configuration/pom.xml $(ADDITIONAL_ARGUMENTS)
 .PHONY: test-unit
 
 _relist-template-service-broker:

--- a/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
@@ -70,7 +70,6 @@ public class CachingServiceTest {
 
    // The eviction can not be turned off on caching service
    @Test(timeout = 600000)
-   @Ignore // TODO remove this when https://issues.jboss.org/browse/ISPN-8577 is resolved
    public void should_put_entries_until_first_one_gets_evicted() {
       hotRodTester.evictionTest(hotRodService);
    }

--- a/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
+++ b/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
@@ -177,19 +177,20 @@ public class HotRodTester implements EndpointTester {
       //given
       RemoteCacheManager cachingService = getRemoteCacheManager(hotRodService, true);
       RemoteCache<String, byte[]> byteArrayCache = cachingService.getCache();
-      byte[] firstValue = generateConstBytes(4096);
-
-      String key = "key";
-      byteArrayCache.put(key, firstValue);
-      assertArrayEquals(firstValue, byteArrayCache.get(key));
-
-      //when the first entry is evicted, the test ends
+      byte[] randomValue = generateConstBytes(1024*1024);
+      int currentCacheSize = -1;
+      int lastCacheSize = -1;
       long counter = 0;
-      while (byteArrayCache.get(key) != null) {
-         byte[] value = generateConstBytes(4096);
 
-         byteArrayCache.put(key + counter++, value);
-         assertArrayEquals(value, byteArrayCache.get(key));
-      }
+      //when
+      do {
+         lastCacheSize = currentCacheSize;
+         String key = "key" + counter++;
+
+         byteArrayCache.put(key, randomValue);
+         assertArrayEquals(randomValue, byteArrayCache.get(key));
+
+         currentCacheSize = byteArrayCache.size();
+      } while (currentCacheSize > lastCacheSize);
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8536

@rmacor It turned out that previous eviction checking algorithm was not correct. The Off-heap uses TinyLFU, which is a Least Frequently Used type of algorithm. Your test always checked the value you inserted before executing the loop. This made it the most frequently used value and therefore it was never evicted. I proposed another approach based on the size. I think it's a bit simpler than your approach.