### PR TITLE
Test snapshot builds with remote OpenShift

### DIFF
--- a/Readme.asciidoc
+++ b/Readme.asciidoc
@@ -122,7 +122,22 @@ This repository has the following structure:
 
 The `image.yaml` uses a Python framework called http://concreate.readthedocs.io/en/develop/[Concreate] to build an image. The easiest way to start the build is to invoke `concreate image.yaml target` and invoke a standard Docker build from the `target` directory.
 
-The `Makefile` contains lots of small, useful scripts. In order to perform a full end-to-end test, invoke `make test-ci`. This will spin up a local OpenShift cluster, build the image, install the template, invoke end-to-end tests and kill the cluster.
+The `Makefile` contains lots of small, useful scripts.
+
+In order to perform a full end-to-end test, invoke `make test-ci`. This will spin up a local OpenShift cluster, build the image, install the template, invoke end-to-end tests and kill the cluster.
+
+In order to run the functional test suite against a remote OpenShift instance, follow these steps:
+
+1. Login to the remote instance from command line using `oc`
+
+   oc login <openshift address> --token=<token>
+
+2. Set the environment variable with the adddress of the remote OpenShift docker registry
+
+   export OPENSHIFT_ONLINE_REGISTRY=<registry address>
+
+3. Invoke `make test-remote`.
+This procedure will create a new project in the remote OpenShift, build the image, push the image to the OpenShift internal registry, install the templates in the project and invoke functional tests.
 
 The `templates` directory contains a template for the Service Catalog. The easiest way to install it is to use `make install-templates-in-openshift-namespace`.
 

--- a/functional-tests/src/test/resources/eap7-testrunner-route.json
+++ b/functional-tests/src/test/resources/eap7-testrunner-route.json
@@ -6,8 +6,7 @@
          "openshift.io/host.generated": "true",
          "haproxy.router.openshift.io/timeout": "5m"
       },
-      "name": "testrunner",
-      "namespace": "myproject"
+      "name": "testrunner"
    },
    "spec": {
       "port": {


### PR DESCRIPTION
* use ImageStreams by the template

This makes it possible to test snapshot builds with a remote OpenShift instance by pushing the bits to OpenShift's internal image registry. The address of the registry must be specified as an environment variable. e.g. `export OPENSHIFT_ONLINE_REGISTRY=registry.free-int.openshift.com`
The procedure for running tests with oc cluster up remains same. The procedure for running tests with remote OpenShift is changed a bit:
1) set OPENSHIFT_ONLINE_REGISTRY env variable, e.g. `export OPENSHIFT_ONLINE_REGISTRY=registry.free-int.openshift.com` 
2) log into OpenShift from command line manually (This is due to fact that different OS clusters require different credentials - e.g. token or password)
3) run make test-remote

