### PR TITLE
CLOUD-2860 Update imagestreams to registry.redhat.io

### DIFF
--- a/templates/caching-service.json
+++ b/templates/caching-service.json
@@ -365,7 +365,7 @@
          "description": "Infinispan image.",
          "name": "IMAGE",
          "required": true,
-         "value": "registry.access.redhat.com/datagrid-7-tech-preview/datagrid-services"
+         "value": "registry.redhat.io/datagrid-7-tech-preview/datagrid-services"
       },
       {
          "description": "Number of instances in the cluster.",

--- a/templates/shared-memory-service.json
+++ b/templates/shared-memory-service.json
@@ -377,7 +377,7 @@
          "description": "Infinispan image.",
          "name": "IMAGE",
          "required": true,
-         "value": "registry.access.redhat.com/datagrid-7-tech-preview/datagrid-services"
+         "value": "registry.redhat.io/datagrid-7-tech-preview/datagrid-services"
       },
       {
          "description": "Number of instances in the cluster.",


### PR DESCRIPTION
The change in this repo is being made just for updating the OpenShift/Library right away.
After the next Data Grid release, the Data Grid and Cache Service images will be unified,
and this will be reflected in OpenShift/Library (this repo will be deprecated).

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>